### PR TITLE
treat command line arguments closer to mongo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 *~
 .*.swp
-cli.js
 lib-js

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,16 @@
 # build *.coffee in lib/ to lib-js/
 LIBS=$(shell find . -regex "^./lib\/.*\.coffee\$$" | sed s/\.coffee$$/\.js/ | sed s/lib/lib-js/)
+TESTS=$(shell cd test && ls *.coffee | sed s/\.coffee$$//)
 
-build: $(LIBS) cli.js
+build: $(LIBS)
 
 lib-js/%.js : lib/%.coffee
 	node_modules/coffee-script/bin/coffee --bare -c -o $(@D) $(patsubst lib-js/%,lib/%,$(patsubst %.js,%.coffee,$@))
 
-cli.js: ./lib-js/cli.js
-	echo "#!/usr/bin/env node" | cat - ./lib-js/cli.js > /tmp/cli.js
-	mv /tmp/cli.js ./cli.js
-	chmod +x ./cli.js
+test: $(TESTS)
 
-# TODO
-test: build
+$(TESTS): build
+	node_modules/mocha/bin/mocha --bail --timeout 60000 --compilers coffee:coffee-script test/$@.coffee
 
 publish:
 	$(eval VERSION := $(shell grep version package.json | sed -ne 's/^[ ]*"version":[ ]*"\([0-9\.]*\)",/\1/p';))

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": "git://github.com/Clever/mongoose-repl.git",
   "bin": {
-    "mongoose": "./cli.js"
+    "mongoose": "./run.js"
   },
   "scripts": {
     "prepublish": "make"
@@ -18,5 +18,8 @@
     "optimist": "~0.6.0",
     "mongoose": "~3.5.15",
     "underscore": "~1.5.1"
+  },
+  "devDependencies": {
+    "mocha": "~1.12.0"
   }
 }

--- a/run.js
+++ b/run.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./lib-js/cli').run()

--- a/test/cli.coffee
+++ b/test/cli.coffee
@@ -1,0 +1,22 @@
+spawn = require('child_process').spawn
+cli = require '../lib/cli'
+assert = require 'assert'
+
+describe "mongoose (cli)", ->
+  
+  it "connects to host localhost by default", ->
+    assert.equal cli.mongo_uri(undefined, 'somedb'), 'localhost/somedb'
+
+  it "connects to db test by default", ->
+    assert.equal cli.mongo_uri('somehost', undefined), 'somehost/test'
+
+  it "connects using a host/db connection string", ->
+    assert.equal cli.mongo_uri(undefined, 'somehost/somedb'), 'somehost/somedb'
+
+  it "connects using the host option", ->
+    assert.equal cli.mongo_uri('somehost', 'somedb'), 'somehost/somedb'
+
+  it "doesn't connect using the host option and a host/db connection string", ->
+    assert.throws ->
+      cli.mongo_uri('somehost', 'anotherhost/somedb')
+    , "url can't have host if you specify it using the --host option"


### PR DESCRIPTION
I bumped the minor version because this change is backwards incompatible. Previously `./cli.js test` would connect to the host test, now it connects to the database test on localhost.
